### PR TITLE
Fix session

### DIFF
--- a/edinburgh.rb
+++ b/edinburgh.rb
@@ -25,7 +25,7 @@ class Edinburgh < Sinatra::Base
     use Rack::Session::Cookie,
       :key => 'rack.session',
       :expire_after => 60 * 60 * 24 * 30,
-      :secret => ENV["RACK_COOKIE_SECRET"]
+      :secret => ENV["RACK_COOKIE_SECRET"] || 'nan-nimo-wakaran-RunDMC'
 
     mime_type :js, 'text/javascript'
     mime_type :css, 'text/css'

--- a/edinburgh.rb
+++ b/edinburgh.rb
@@ -36,11 +36,14 @@ class Edinburgh < Sinatra::Base
   end
 
   helpers do
-    def logged_in?
-      !session[:client].nil?
-    end
-    def current_client
-      session[:client]
+    def client
+      return nil if session[:credentials].nil?
+      @client || Twitter::REST::Client.new do |config|
+        config.consumer_key        = ENV["CONSUMER_KEY"]
+        config.consumer_secret     = ENV["CONSUMER_SECRET"]
+        config.access_token        = session[:credentials][:token]
+        config.access_token_secret = session[:credentials][:secret]
+      end
     end
     def format_tweet_base(tweet)
       user = tweet.user
@@ -107,16 +110,10 @@ class Edinburgh < Sinatra::Base
   get '/auth/twitter/callback' do
     auth_hash = env['omniauth.auth']
     #p auth_hash
-    credentials = auth_hash[:credentials]
-    #p credentials
 
-    client = Twitter::REST::Client.new do |config|
-      config.consumer_key        = ENV["CONSUMER_KEY"]
-      config.consumer_secret     = ENV["CONSUMER_SECRET"]
-      config.access_token        = credentials[:token]
-      config.access_token_secret = credentials[:secret]
-    end
-    #p client
+    # p client
+    session[:credentials] = auth_hash[:credentials]
+    # p client
 
     # Edinburgh, Scotland
     geoopts = {
@@ -129,7 +126,6 @@ class Edinburgh < Sinatra::Base
     #p place
 
     #session[:auth_hash] = auth_hash
-    session[:client] = client
     session[:opts] = { :place => place }
     session[:message] = 'logged in'
 
@@ -158,7 +154,7 @@ class Edinburgh < Sinatra::Base
   end
 
   get '/api/home_timeline' do
-    return 401 unless logged_in?
+    return 401 if client.nil?
 
     # p params
     # TODO, add count-number setting
@@ -170,7 +166,6 @@ class Edinburgh < Sinatra::Base
     end
     # p opts
 
-    client = session[:client]
     begin
       tweets = client.home_timeline(opts)
     rescue => evar
@@ -195,7 +190,6 @@ class Edinburgh < Sinatra::Base
     # p params
     #text = "#{params[:text]} : #{Time.now().to_s}"
     text = params[:text]
-    client = session[:client]
     #p client
     opts = session[:opts]
     #p opts
@@ -206,8 +200,6 @@ class Edinburgh < Sinatra::Base
       @message = "ng"
     end
     #p res
-    session[:message] = ''
-    #erb :index
     @message
   end
 


### PR DESCRIPTION
- not to hold entire `client` but only `credential`
- make `client` per request
  - because sinatra makes an instance per request
    - can't use instance var in `get`
